### PR TITLE
Fix line break bug

### DIFF
--- a/static/css/mini-news.css
+++ b/static/css/mini-news.css
@@ -48,4 +48,5 @@
 .line-clamp3 {
   line-clamp: 3;
   overflow: hidden;
+  display: block;
  }


### PR DESCRIPTION
Because `line-clamp` expects the element to be a `block` we need to explicitly it in the CSS.